### PR TITLE
장바구니/로그인 기능 및 불필요한 부분 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,6 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.

--- a/src/component/Cart.js
+++ b/src/component/Cart.js
@@ -3,8 +3,9 @@ import '../css/Cart.css'
 import { NavLink } from 'react-router-dom';
 import { CartDataAxios, CartListDeleteAxios } from './common/api.js';
 import MainPageHeader from './mainpage/MainPageHeader';
+import { connect } from 'react-redux';
 
-function Cart()
+function Cart({loginState,history})
 {
     const [cartData,setCartData] = useState({});
     const [cartList,setCartList] = useState([]);
@@ -215,78 +216,91 @@ function Cart()
         )
     })
 
-    return(
-        <div>
-            <MainPageHeader/>
-            <div className="cart_body">
-            { cartList.length > 0 ? <div>
-                    <table className="cart_table">
-                        <thead>
-                            <tr className="table_title">
-                                <th scope="col" className="table_title_part"><input type="checkbox" onChange={onAllCheck} checked={checkCount === cartList.length}/></th>
-                                <th scope="col" className="table_title_part">상품정보</th>
-                                <th scope="col" className="table_title_part">옵션</th>
-                                <th scope="col" className="table_title_part">상품금액</th>
-                                <th scope="col" className="table_title_part">배송비</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {itemListMap}
-                        </tbody>
-                    </table>
 
-                    <div className="prd_check_btn_area">
-                            <div className="checkbox_input"><input type="checkbox" onChange={onAllCheck} checked={checkCount === cartList.length}/></div>
-                            <button onClick={checkPrdDel}>선택상품 삭제</button>
-                    </div>
-                    <div className="order_calculator">
-                        <div className="prd_price_detail">
-                            <dl className="prd_price_detail_text_area">
-                                <dt>총 상품금액</dt>
-                                <dd>
-                                <span className="prd_price_detail_text1">{prdTotal}</span>    
-                                    원
-                                </dd>
-                            </dl>
-                            <span className="order_calculator_mark">+</span>
-                            <dl className="prd_price_detail_text_area">
-                                <dt>배송비</dt>
-                                <dd>
-                                <span className="prd_price_detail_text1">{deliveryprice}</span>    
-                                    원
-                                </dd>
-                            </dl>
-                            <span className="order_calculator_mark">-</span>
-                            <dl className="prd_price_detail_text_area">
-                                <dt>할인예상금액</dt>
-                                <dd className="discount_text">
-                                <span className="prd_price_detail_text1">0</span>    
-                                    원
-                                </dd>
-                            </dl>
+    if(!loginState)
+    {
+        history.push('/');
+        return null;
+    }else{
+        return(
+            <div>
+                <MainPageHeader/>
+                <div className="cart_body">
+                { cartList.length > 0 ? <div>
+                        <table className="cart_table">
+                            <thead>
+                                <tr className="table_title">
+                                    <th scope="col" className="table_title_part"><input type="checkbox" onChange={onAllCheck} checked={checkCount === cartList.length}/></th>
+                                    <th scope="col" className="table_title_part">상품정보</th>
+                                    <th scope="col" className="table_title_part">옵션</th>
+                                    <th scope="col" className="table_title_part">상품금액</th>
+                                    <th scope="col" className="table_title_part">배송비</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {itemListMap}
+                            </tbody>
+                        </table>
+    
+                        <div className="prd_check_btn_area">
+                                <div className="checkbox_input"><input type="checkbox" onChange={onAllCheck} checked={checkCount === cartList.length}/></div>
+                                <button onClick={checkPrdDel}>선택상품 삭제</button>
                         </div>
-                        <div className="prd_price_total">
-                            <span className="prd_price_total_text">총 주문금액</span>
-                            <span className="prd_price_total_num">
-                                <span className="prd_price_total_num_text">{prdTotal+deliveryprice}</span>
-                                원
-                            </span>
+                        <div className="order_calculator">
+                            <div className="prd_price_detail">
+                                <dl className="prd_price_detail_text_area">
+                                    <dt>총 상품금액</dt>
+                                    <dd>
+                                    <span className="prd_price_detail_text1">{prdTotal}</span>    
+                                        원
+                                    </dd>
+                                </dl>
+                                <span className="order_calculator_mark">+</span>
+                                <dl className="prd_price_detail_text_area">
+                                    <dt>배송비</dt>
+                                    <dd>
+                                    <span className="prd_price_detail_text1">{deliveryprice}</span>    
+                                        원
+                                    </dd>
+                                </dl>
+                                <span className="order_calculator_mark">-</span>
+                                <dl className="prd_price_detail_text_area">
+                                    <dt>할인예상금액</dt>
+                                    <dd className="discount_text">
+                                    <span className="prd_price_detail_text1">0</span>    
+                                        원
+                                    </dd>
+                                </dl>
+                            </div>
+                            <div className="prd_price_total">
+                                <span className="prd_price_total_text">총 주문금액</span>
+                                <span className="prd_price_total_num">
+                                    <span className="prd_price_total_num_text">{prdTotal+deliveryprice}</span>
+                                    원
+                                </span>
+                            </div>
                         </div>
-                    </div>
-                    <div className="cart_button_box">
-                        <NavLink to='/' className="link_home">쇼핑 계속하기</NavLink>
-                        <button>주문하기</button>
-                    </div>
-                </div> :
-                    <div className="cart_empty">
-                        <p className="cart_empty_text1">장바구니에 담긴 상품이 없습니다.</p>
-                        <p className="cart_empty_text2">원하는 상품을 장바구니에 담아보세요.</p>
-                        <NavLink to='/' className="link_home">쇼핑 계속하기</NavLink>
-                    </div>
-                }
+                        <div className="cart_button_box">
+                            <NavLink to='/' className="link_home">쇼핑 계속하기</NavLink>
+                            <button>주문하기</button>
+                        </div>
+                    </div> :
+                        <div className="cart_empty">
+                            <p className="cart_empty_text1">장바구니에 담긴 상품이 없습니다.</p>
+                            <p className="cart_empty_text2">원하는 상품을 장바구니에 담아보세요.</p>
+                            <NavLink to='/' className="link_home">쇼핑 계속하기</NavLink>
+                        </div>
+                    }
+                </div>
             </div>
-        </div>
-    )
+        )
+    }
 }
 
-export default Cart;
+const mapStateToProps = state =>({
+    loginState : state.GlobalData.glogin
+})
+
+export default connect(
+    mapStateToProps
+)(Cart);

--- a/src/component/Cart.js
+++ b/src/component/Cart.js
@@ -130,7 +130,7 @@ function Cart({loginState,history})
     // 장바구니 상품 리스트 맵
     const itemListMap = cartList.map((arr,index)=>{
         return(
-                <tr key={arr.cart_id}>
+                <tr key={index}>
                 <td className="cart_item_cell">
                     <input type="checkbox" 
                            onChange={()=>checklist(arr.cart_id)} 

--- a/src/component/LogIn.js
+++ b/src/component/LogIn.js
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import '../css/Login.css'
 import { connect } from 'react-redux';
-import { gMemberId, gMemberName } from '../store/modules/GlobalData.js'
+import { gMemberId, gMemberName, gLoginState } from '../store/modules/GlobalData.js'
 import { LoginPostAxios } from './common/api.js';
 
-function LogIn({history,gMemberId,gMemberName})
+function LogIn(props)
 {
+    const {history,gMemberId,gMemberName, loginState} = props;
     const [inputId,setInputId] = useState('');
     const [inputPw,setInputPw] = useState('');
 
@@ -23,6 +24,7 @@ function LogIn({history,gMemberId,gMemberName})
         LoginPostAxios(inputId,inputPw).then((response)=>{
             if(response.data.result === 0)
             {
+                loginState(true);
                 gMemberId(response.data.user_data.id);
                 gMemberName(response.data.user_data.name)
                 history.push('/');
@@ -81,7 +83,8 @@ const mapStateToProps = state =>({
 
 const mapDispatchToProps = dispatch =>({
     gMemberId: id => dispatch(gMemberId(id)),
-    gMemberName: name => dispatch(gMemberName(name))
+    gMemberName: name => dispatch(gMemberName(name)),
+    loginState:  state => dispatch(gLoginState(state))
 })
 
 export default connect(

--- a/src/component/Products.js
+++ b/src/component/Products.js
@@ -193,9 +193,9 @@ function Products(props){
     }
 
     // optionListArr의 값을 map으로 뿌려주며 추가된 상품의 ui가 생성됨 
-    const optionList = optionListArr.map((arr,num)=>{
+    const optionList = optionListArr.map((arr,num,idx)=>{
         return(
-            <li key={arr.id}>
+            <li key={idx}>
                 <span className="list_prd">{arr.name}</span>
                 <div className="list_count">
                     {<button className="delBtn" onClick={()=>onRemove(num,optionListArr,'option')}>X</button>}
@@ -211,9 +211,9 @@ function Products(props){
     })
 
     // addPrdListArr의 값을 map으로 뿌려주며 추가된 상품의 ui가 생성됨
-    const addPrdList = addPrdListArr.map((arr,num)=>{
+    const addPrdList = addPrdListArr.map((arr,num,idx)=>{
         return(
-            <li key={arr.id}>
+            <li key={idx}>
                 <span className="list_prd">{arr.name}</span>
                 <div className="list_count">
                     <button className="delBtn" onClick={()=>onRemove(num,addPrdListArr,'addPrd')}>X</button>
@@ -321,8 +321,8 @@ function Products(props){
     }
 
     // deliveryMethod의 들어있는 data값으로 selectbox에 들어갈 option을 생성함
-    const deliverySel = deliveryMethod.map((arr)=>{
-        return <option key={arr.id} value={arr.id}>{arr.name}</option>
+    const deliverySel = deliveryMethod.map((arr,idx)=>{
+        return <option key={idx} value={arr.id}>{arr.name}</option>
     })
 
     // 무이자 상품 자세히보기 활성화 
@@ -394,9 +394,9 @@ function Products(props){
                     <NavLink to="/">홈</NavLink>
                         <span className="bar">{'>'}</span>
                     {
-                        categoryList.map((list,num)=>{
+                        categoryList.map((list,num,idx)=>{
                                 return (
-                                    <Fragment key={list.id}>
+                                    <Fragment key={idx}>
                                     <NavLink to={"/CategoryPrdList/"+list.id}>{list.name}{categoryList.length === num+1 && "(총"+list.num+"개)"}  </NavLink>
                                     {categoryList.length !== num+1 && <span className="bar">{'>'}</span>}
                                     </Fragment>)
@@ -474,13 +474,13 @@ function Products(props){
                                             <div className="option">
                                                 <span>옵션</span>
                                                 {
-                                                    prdOption.map((option_item) => {
+                                                    prdOption.map((option_item,idx) => {
                                                         return (
-                                                            <select key={option_item.id} onChange={(e) => onSelectValue(prdOption,optionListArr,'option',option_item.id,e)}>
+                                                            <select key={idx} onChange={(e) => onSelectValue(prdOption,optionListArr,'option',option_item.id,e)}>
                                                                 <option value='0'>{option_item.name}</option>
                                                                 {
-                                                                    option_item.option_list.map((list)=>{
-                                                                        return <option key={list.id}  value={list.id}>{list.name}{list.add_price ? "  ("+list.add_price+"원)추가" : ''} {list.soldout ? "(품절)": ''}</option>
+                                                                    option_item.option_list.map((list,idx)=>{
+                                                                        return <option key={idx}  value={list.id}>{list.name}{list.add_price ? "  ("+list.add_price+"원)추가" : ''} {list.soldout ? "(품절)": ''}</option>
                                                                     })
                                                                 }
                                                             </select>
@@ -493,13 +493,13 @@ function Products(props){
                                             <span>추가상품</span>
                                             <div className="select_area">
                                                 {
-                                                    addPrd.map((addItem) => {
+                                                    addPrd.map((addItem,idx) => {
                                                         return (
-                                                            <select key={addItem.id} onChange={(e) => onSelectValue(addPrd,addPrdListArr,'addPrd',addItem.id,e)}>
+                                                            <select key={idx} onChange={(e) => onSelectValue(addPrd,addPrdListArr,'addPrd',addItem.id,e)}>
                                                                 <option value='0'>{addItem.name}</option>
                                                                 {
-                                                                    addItem.product_list.map((list)=>{
-                                                                     return <option key={list.id} value={list.id}>{list.name} {list.price}원 {list.soldout ? "(품절)": ''}</option>
+                                                                    addItem.product_list.map((list,idx)=>{
+                                                                     return <option key={idx} value={list.id}>{list.name} {list.price}원 {list.soldout ? "(품절)": ''}</option>
                                                                     })
                                                                 }
                                                             </select>

--- a/src/component/Products.js
+++ b/src/component/Products.js
@@ -5,12 +5,12 @@ import ProductsInfo from './ProductsInfo'
 import Installment from './Installment';
 import MainPageHeader from './mainpage/MainPageHeader';
 import { connect } from 'react-redux';
-import { gCartCountIncrease } from '../store/modules/GlobalData.js'
+import { gCartCountIncrease, gNowPage } from '../store/modules/GlobalData.js'
 import { ProductsCartAddAxios, ProductsDataAxios } from './common/api.js';
 
 function Products(props){
 
-    const {match,history,gCartCountIncrease} = props;
+    const {match,history,gCartCountIncrease,loginState, nowPage} = props;
     const [prdData,setPrdData] = useState({});
     const [categoryList,setCategoryList] = useState([])
     const [deliveryMethod,setDeliveryMethod] = useState([]);
@@ -34,6 +34,7 @@ function Products(props){
        ProductsDataAxios(match.params.id).then((response)=>{
             setPrdData(response.data);
             setCategoryList(response.data.category_list);
+            console.log(response.data.category_list);
             setPrdImg(response.data.product_image);
             setImgState(response.data.product_image[0].url);
             setDeliveryMethod(response.data.delivery_method);
@@ -342,7 +343,15 @@ function Products(props){
 
         if(optionListArr.length === 0 && prdOption.length !== 0)
         {
-            alert('옵션을 선택하지 않으셨습니다. 옵션을 선택해 주세요.')
+            alert('옵션을 선택하지 않으셨습니다. 옵션을 선택해 주세요.');
+        }
+        else if(!loginState)
+        {
+            const loginConfirm = window.confirm("로그인이 필요한 서비스입니다. 로그인 하시겠습니까?");
+            if(loginConfirm)
+            {
+                history.push('/LogIn');
+            }
         }
         else{
             let postOption = [];
@@ -365,10 +374,15 @@ function Products(props){
                 const cartPageConfirm = window.confirm('장바구니에 상품을 담았습니다.\n장바구니로 이동하시겠습니까?');
                 if(cartPageConfirm)
                 {
+                    nowPage('cart');
                     history.push('/Cart');
                 }
             })
         }
+    }
+
+    const nullEvent = () =>{
+        alert("아직 구현되지 않은 기능입니다.");
     }
     
     return(
@@ -383,7 +397,7 @@ function Products(props){
                         categoryList.map((list,num)=>{
                                 return (
                                     <Fragment key={list.id}>
-                                    <NavLink to={"/category/"+list.id}>{list.name}{categoryList.length === num+1 && "(총"+list.num+"개)"}  </NavLink>
+                                    <NavLink to={"/CategoryPrdList/"+list.id}>{list.name}{categoryList.length === num+1 && "(총"+list.num+"개)"}  </NavLink>
                                     {categoryList.length !== num+1 && <span className="bar">{'>'}</span>}
                                     </Fragment>)
                             })
@@ -516,7 +530,7 @@ function Products(props){
                                         </span>
                                     </div>
                                     <div className="btn_area">
-                                        <div className="buy_btn btn_bg">
+                                        <div className="buy_btn btn_bg" onClick={nullEvent}>
                                             <div>구매하기</div>
                                         </div>
                                         <div className="basket_btn btn_bg" onClick={onAddCart}>
@@ -539,11 +553,12 @@ function Products(props){
 }
 
 const mapStateToProps = state =>({
-
+    loginState : state.GlobalData.glogin
 })
 
 const mapDispatchToProps = dispatch =>({
-    gCartCountIncrease: count => dispatch(gCartCountIncrease(count))
+    gCartCountIncrease: count => dispatch(gCartCountIncrease(count)),
+    nowPage: page => dispatch(gNowPage(page))
 })
 
 export default connect(

--- a/src/component/ProductsInfo.js
+++ b/src/component/ProductsInfo.js
@@ -43,12 +43,9 @@ function ProductsInfo({data})
     }
 
     // qna ui 출력
-    const qnaListMap = data.qna.map((arr)=>{
-
-
-        
+    const qnaListMap = data.qna.map((arr,idx)=>{
         return(
-            <li key={arr.id}>
+            <li key={idx}>
                 {(qnaState === "0" ||  parseInt(qnaState) === arr.status) &&
                 <div className="qna_table">
                     <div className="qna_state">

--- a/src/component/ProductsList/PrdList.js
+++ b/src/component/ProductsList/PrdList.js
@@ -70,22 +70,22 @@ function PrdList({sortTypeArr,ListAxios,data,listType})
 
     // listViewOption값에 따라 보여주는 page 타입이 바뀜
     // 상품 리스트 맵
-    const itemList = listItemData.map((arr)=>{
+    const itemList = listItemData.map((arr,idx)=>{
         if(listViewOption === 1)
         {
-          return  <ListViewTypeA key={arr.id} arr={arr} saleCal={saleCal}/>
+          return  <ListViewTypeA key={idx} arr={arr} saleCal={saleCal}/>
         }
         else if(listViewOption === 2)
         {
-          return  <ListViewTypeB key={arr.id} arr={arr} saleCal={saleCal}/>
+          return  <ListViewTypeB key={idx} arr={arr} saleCal={saleCal}/>
         }
         else if(listViewOption === 3)
         {
-          return  <ListViewTypeC key={arr.id} arr={arr} saleCal={saleCal}/>
+          return  <ListViewTypeC key={idx} arr={arr} saleCal={saleCal}/>
         }
         else if(listViewOption === 4)
         {
-          return  <ListViewTypeD key={arr.id} arr={arr} saleCal={saleCal}/>
+          return  <ListViewTypeD key={idx} arr={arr} saleCal={saleCal}/>
         }
 
         return 0;

--- a/src/component/ProductsList/PrdList.js
+++ b/src/component/ProductsList/PrdList.js
@@ -93,9 +93,9 @@ function PrdList({sortTypeArr,ListAxios,data,listType})
 
     //현재 페이지에서 보여 줄수 있는 상품의 개수의 값
     //perPage의 기능은 아직 추가되지 않음
-    const onPerPage = (e) =>{
-        setPerPage(e.target.options[e.target.selectedIndex].value);
-    }
+    // const onPerPage = (e) =>{
+    //     setPerPage(e.target.options[e.target.selectedIndex].value);
+    // }
 
     // 페이지네이션 포커스 
     const onPageFocus = (num) =>{
@@ -143,14 +143,14 @@ function PrdList({sortTypeArr,ListAxios,data,listType})
                         </ul>
                         
                         <div className="sort_option">
-                            <div className="sort_selectBox">
+                            {/* <div className="sort_selectBox">
                                 <select value={perPage} onChange={onPerPage}>
                                     <option value="20">20개씩 보기</option>
                                     <option value="40">40개씩 보기</option>
                                     <option value="60">60개씩 보기</option>
                                     <option value="80">80개씩 보기</option>
                                 </select>
-                            </div>
+                            </div> */}
                             
                             <div className="sort_view_type">
                                 <ul>

--- a/src/component/ProductsList/PrdList.js
+++ b/src/component/ProductsList/PrdList.js
@@ -28,7 +28,7 @@ function PrdList({sortTypeArr,ListAxios,data,listType})
     const [listViewOption,setListViewOption] = useState(2);
     const [sortType,setSortType] = useState('popular');
     const [nowPage,setNowPage] = useState(1);
-    const [perPage,setPerPage] = useState(40);
+    const [perPage] = useState(40);
     const [pagination,setPagination] = useState();  
 
     useEffect(()=>{  

--- a/src/component/mainpage/MainPageAllPrd.js
+++ b/src/component/mainpage/MainPageAllPrd.js
@@ -27,9 +27,9 @@ function MainPageAllPrd()
     }
 
     // 상품 리스트 맵
-    const itemListMap = itemList.map((arr)=>{
+    const itemListMap = itemList.map((arr,idx)=>{
         return(
-            <li key={arr.id} className="allprd_list_li">
+            <li key={idx} className="allprd_list_li">
                 <NavLink  to={"/Products/"+arr.id} className="allprd_list_atag">
                     <div className="allprd_list_thumbnail">
                         <img src={arr.thumb_image} alt="img"/>

--- a/src/component/mainpage/MainPageBestPrd.js
+++ b/src/component/mainpage/MainPageBestPrd.js
@@ -18,9 +18,9 @@ function MainPageBestPrd()
     },[])
 
     // 상단 상품리스트 맵
-    const topDataMap = topData.map((arr)=>{
+    const topDataMap = topData.map((arr,idx)=>{
         return(
-            <li key={arr.product_id}>
+            <li key={idx}>
                 <NavLink to={"/Products/"+arr.product_id} className="bestreview_atag">
                     <div className="bestreview_thumbnail">
                         <img src={arr.thumb_image} alt="img"/>
@@ -47,9 +47,9 @@ function MainPageBestPrd()
     })
 
     // 하단 상품리스트 맵
-    const bottomDataMap = bottomData.map((arr)=>{
+    const bottomDataMap = bottomData.map((arr,idx)=>{
         return(
-            <li key={arr.product_id}>
+            <li key={idx}>
                 <NavLink to={"/Products/"+arr.product_id} className="listview_atag">
                     <div className="bestreview_thumbnail">
                         <img src={arr.thumb_image} alt="img"/>

--- a/src/component/mainpage/MainPageHeader.js
+++ b/src/component/mainpage/MainPageHeader.js
@@ -122,9 +122,9 @@ function MainPageHeader(props)
         return(
             <div className="categoryMouseOver_list">
                 <ul>
-                    {data.map((sub)=>{
+                    {data.map((sub,idx)=>{
                         return(
-                            <li key={sub.id} className="category_name2" 
+                            <li key={idx} className="category_name2" 
                                 onMouseEnter={()=>categoryMouseOver(sub.id,num)}
                                 onClick={()=>{onReset()}}
                             ><NavLink to={"/CategoryPrdList/"+sub.id}>{sub.name}</NavLink></li>
@@ -136,9 +136,9 @@ function MainPageHeader(props)
     }
 
     // 상품 카테고리 맵
-    const categoryMap = categoryData.map((arr)=>{
+    const categoryMap = categoryData.map((arr,idx)=>{
         return(
-            <li key={arr.id}
+            <li key={idx}
                 className="category_inner_li" 
                 onMouseLeave={categoryMouseOut}
                 onClick={()=>{onReset()}}>

--- a/src/component/mainpage/MainPageHeader.js
+++ b/src/component/mainpage/MainPageHeader.js
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from 'react';
 import '../../css/MainPage.css'
 import { NavLink, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { gMemberId, gMemberName, gCartCount, gDataReset } from '../../store/modules/GlobalData.js'
+import { gMemberId, gMemberName, gCartCount, gDataReset, gNowPage } from '../../store/modules/GlobalData.js'
 import { MainPageHeaderAxios, MainPageHeaderCountAxios, MainPageHeaderLogoutAxios } from '../common/api';
 
 function MainPageHeader(props)
 {
-    const {history,gName,gCount,gCartCount,gDataReset} = props;
+    const {history,loginState,gName,gCount,gCartCount,gDataReset,nowPage,page} = props;
     const [headerData,setHeaderData] = useState({});
     const [categoryData,setCategoryData] = useState([]);
     const [subCategoryData,setSubCategoryData] = useState([]);
@@ -54,6 +54,10 @@ function MainPageHeader(props)
     const onLogOut = () =>{
         MainPageHeaderLogoutAxios().then(()=>{
             gDataReset();
+            if(page === "cart")
+            {
+                history.push('/login');
+            }
         })
     }
 
@@ -158,6 +162,10 @@ function MainPageHeader(props)
         )
     })
 
+    const onPageChange = () =>{
+        nowPage('cart');
+    }
+
     return(
         <div className="layout_header">
             <div className="header_shopping">
@@ -165,14 +173,8 @@ function MainPageHeader(props)
                     <div className="globla_area">
                         <div className="header_menu">
                             <div className="menu_area">
+                                {!loginState ? 
                                 <ul>
-                                    <li>
-                                        <NavLink to="/Cart">
-                                            <span>장바구니{gCount > 0 && "("+gCount+")"}</span>
-                                        </NavLink>
-                                    </li>
-                                    {!gName ? 
-                                    <>
                                     <li>
                                         <NavLink to="/Login">
                                             <span>로그인</span>
@@ -183,8 +185,13 @@ function MainPageHeader(props)
                                         <span>회원가입</span>
                                     </NavLink>
                                     </li> 
-                                    </> :
-                                    <>
+                                </ul> :
+                                <ul>
+                                    <li>
+                                        <NavLink to="/Cart" onClick={onPageChange}>
+                                            <span>장바구니{gCount > 0 && "("+gCount+")"}</span>
+                                        </NavLink>
+                                    </li>
                                     <li>
                                         <span>{gName+"님"}</span>
                                     </li>
@@ -192,8 +199,8 @@ function MainPageHeader(props)
                                         <div className="Logout" onClick={onLogOut}>
                                             <span>로그아웃</span>
                                         </div>
-                                    </li></>}
-                                </ul>
+                                    </li>
+                                </ul>}
                             </div>
                         </div>
                     </div>
@@ -233,7 +240,9 @@ function MainPageHeader(props)
 
 const mapStateToProps = state =>({
     gCount: state.GlobalData.gCount,
-    gName: state.GlobalData.gName
+    gName: state.GlobalData.gName,
+    loginState : state.GlobalData.glogin,
+    page: state.GlobalData.gPage
 })
 
 const mapDispatchToProps = dispatch =>({
@@ -241,6 +250,7 @@ const mapDispatchToProps = dispatch =>({
     gMemberName: name => dispatch(gMemberName(name)),
     gCartCount: count => dispatch(gCartCount(count)),
     gDataReset: ()=> dispatch(gDataReset()),
+    nowPage: page => dispatch(gNowPage(page))
 })
 
 export default connect(

--- a/src/store/modules/GlobalData.js
+++ b/src/store/modules/GlobalData.js
@@ -3,17 +3,23 @@ const CART_COUNT_INCREASE = 'CART_COUNT_INCREASE';
 const MEMBER_ID = 'MEMBER_ID';
 const MEMBER_NAME = 'MEMBER_NAME';
 const DATA_RESET = 'DATA_RESET';
+const LOGIN_STATE = 'LOGIN_STATE';
+const NOW_PAGE = 'NOW_PAGE';
 
 export const gCartCount = count =>({type:CART_COUNT,count});
 export const gCartCountIncrease = count =>({type:CART_COUNT_INCREASE,count});
 export const gMemberId = id =>({type:MEMBER_ID,id});
 export const gMemberName = name =>({type:MEMBER_NAME,name});
 export const gDataReset = () =>({type:DATA_RESET});
+export const gLoginState = state =>({type:LOGIN_STATE, state});
+export const gNowPage = page =>({type:NOW_PAGE, page});
 
 const initialState = {
     gCount: 0,
     gId: '',
-    gName: ''
+    gName: '',
+    glogin: false,
+    gPage: 'main'
 }
 
 export default function GlobalData(state = initialState, action){
@@ -44,7 +50,18 @@ export default function GlobalData(state = initialState, action){
                 ...state,
                 gCount: 0,
                 gId: '',
-                gName: ''
+                gName: '',
+                glogin: false
+            }
+        case LOGIN_STATE:
+            return{
+                ...state,
+                glogin: action.state
+            }
+        case NOW_PAGE:
+            return{
+                ...state,
+                gPage: action.page
             }
         default:
             return state;


### PR DESCRIPTION
- loginState, nowpage 글로벌 상태값 추가
- 로그인이 아닐 경우 header의 장바구니탭 비활성화
- 상품의 장바구니 클릭 시 로그인이 아닐 경우  confirm으로 로그인 진행을 물음
- 장바구니 창에서 로그아웃 하였을 경우 로그인 페이지로 넘어가며 로그인을 하지 않을 경우 메인 페이지로 넘어가도록 함
- 로그아웃 이후 뒤로가기로 장바구니 페이지로 접근할 경우 접근하지 못하도록 메인 페이지를 띄움
- 구매하기 버튼 클릭 시 미구현 메시지를 alert으로 띄움
-onperpage(20개,40개,60,80개 list 뿌리는 기능) 주석처리